### PR TITLE
First meaningful functionality

### DIFF
--- a/datalad_ebrains/kg_query.py
+++ b/datalad_ebrains/kg_query.py
@@ -1,0 +1,180 @@
+import logging
+from os import environ
+import requests
+import json
+
+from datalad.downloaders.credentials import Token
+
+lgr = logging.getLogger('datalad.ebrains.kg_query')
+
+# use query endpoint of a stored query for datasets
+# see tools/kg_query.py
+# TODO this is a temporary stored query, finalize!
+kg_dataset_query = \
+    "https://kg.humanbrainproject.eu/query/minds/core/dataset/v1.0.0/mih_ds"
+
+ds_id_key = 'https://schema.hbp.eu/myQuery/identifier'
+ds_revision_key = 'https://schema.hbp.eu/myQuery/wasRevisionOf'
+ds_filelist_key = 'https://schema.hbp.eu/myQuery/v1.0.0'
+type_key = 'https://schema.hbp.eu/myQuery/@type'
+
+
+def get_auth_headers(token):
+    """Get token-based auth headers for a KG HTPP request
+
+    Parameters
+    ----------
+    token: str
+      EBRAINS Auth-token
+
+    Returns
+    -------
+    dict
+      Auth headers as a dict, fit for requests.get()
+    """
+    return {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer {}'.format(token)
+    }
+
+
+def query_kg4dataset(auth_token, dataset_id):
+    """Query KG for metadata on a given dataset
+
+    Parameters
+    ----------
+    token: str
+      EBRAINS Auth-token
+    dataset_id: str
+      UUID of the target dataset
+
+    Returns
+    -------
+
+    """
+    # parameterize query with dataset ID
+    url = "{}/instances?databaseScope=RELEASED&datasetId={}".format(
+        kg_dataset_query,
+        dataset_id,
+    )
+    # perform the request
+    r = requests.get(
+        url,
+        headers=get_auth_headers(auth_token),
+    )
+    if not r.ok:
+        raise KGQueryException(
+            "request at {} failed ({}){}{}".format(
+                r.url,
+                r.status_code,
+                ': ' if r.text else '',
+                r.text))
+
+    qres = json.loads(r.content)
+    qres = validate_query_results(qres, dataset_id)
+    return qres
+
+
+def get_token(allow_interactive=True):
+    # prefer the environment
+    if 'EBRAINS_TOKEN' in environ:
+        return environ['EBRAINS_TOKEN']
+
+    # fall back on DataLad credential manager
+    token_auth = Token(
+        name='https://kg.humanbrainproject.eu/query',
+        url='https://nexus-iam.humanbrainproject.org/v0/oauth2/authorize',
+    )
+    do_interactive = allow_interactive and ui.is_interactive()
+
+    # get auth token, from environment, or from datalad credential store
+    # if known-- we do not support first-time entry during a test run
+    token = environ.get(
+        'EBRAINS_TOKEN',
+        token_auth().get('token', None)
+        if do_interactive or token_auth.is_known
+        else None)
+
+    return token
+
+
+class KGQueryException(RuntimeError):
+    pass
+
+
+def validate_query_results(res, dataset_id):
+    """Perform basic validation of query result structure
+
+    Parameters
+    ----------
+    res : dict
+      Decoded JSON of query result
+    dataset_id: str
+      UUID of the target dataset
+
+    Returns
+    -------
+    list
+      Content of the first and only item in the `result` property
+      list of the query output.
+    """
+    r = res.get('results', [])
+    if not len(r):
+        raise KGQueryException("yielded no result records")
+
+    if len(r) > 1:
+        raise KGQueryException("yielded more than one record")
+
+    if res.get('start', None) != 0 \
+            or res.get('size', 0)  != 1 \
+            or res.get('total', 0) != 1:
+        raise KGQueryException("results have unexpected/unsupported structure")
+
+    # there is only a single record, simplify
+    ds_res = r[0]
+
+    if ds_res.get(ds_id_key) != dataset_id:
+        raise KGQueryException(
+            "results mismatch requested dataset ID")
+    return ds_res
+
+
+def get_kgds_parent_id(kgds):
+    """Return ID of parent revision of the given dataset record
+
+    Returns
+    -------
+    str or None
+      If no revision ID is found, None is returned
+    """
+    revof = kgds.get(ds_revision_key, [])
+    if not revof:
+        return None
+    if len(revof) > 1:
+        lgr.warn(
+            "More than on 'wasRevisionOf' for dataset record, "
+            "proceeding with first entry "
+            "(dataset will have incomplete version history)")
+    return revof[0].get('https://schema.hbp.eu/myQuery/identifier', None)
+
+
+def get_annex_key_records(kgds):
+    """Map the KG query to a dict-per-file with properties for addurls
+
+    Yields
+    ------
+    dict
+    """
+    for rec in kgds.get(ds_filelist_key, []):
+        if not rec.get(type_key, None) == 'https://schema.hbp.eu/cscs/File':
+            lgr.warn('Found non-file-type record, ignored')
+        yield dict(
+            url=rec['https://schema.hbp.eu/myQuery/absolute_path'],
+            name=rec['https://schema.hbp.eu/myQuery/name'],
+            md5sum=rec['https://schema.hbp.eu/myQuery/hash'],
+            size=int(rec['https://schema.hbp.eu/myQuery/byte_size']),
+            content_type=rec['https://schema.hbp.eu/myQuery/content_type'],
+            last_modifier=rec[
+                'https://schema.hbp.eu/myQuery/lastModificationUserId'],
+            last_modified=rec['https://schema.hbp.eu/myQuery/last_modified'],
+        )

--- a/tools/kg_query.json
+++ b/tools/kg_query.json
@@ -1,0 +1,326 @@
+{
+  "@context": {
+    "@vocab": "https://schema.hbp.eu/graphQuery/",
+    "query": "https://schema.hbp.eu/myQuery/",
+    "fieldname": {
+      "@id": "fieldname",
+      "@type": "@id"
+    },
+    "merge": {
+      "@type": "@id",
+      "@id": "merge"
+    },
+    "relative_path": {
+      "@id": "relative_path",
+      "@type": "@id"
+    }
+  },
+  "fields": [
+    {
+      "fieldname": "query:wasRevisionOf",
+      "relative_path": "http://www.w3.org/ns/prov#wasRevisionOf",
+      "fields": [
+          {
+            "fieldname": "query:identifier",
+            "relative_path": "http://schema.org/identifier"
+          },
+          {
+            "fieldname": "query:@id",
+            "relative_path": "@id"
+          }
+        ]
+    },
+    {
+      "fieldname": "query:component",
+      "relative_path": "https://schema.hbp.eu/minds/component",
+      "fields": [
+        {
+          "fieldname": "query:@id",
+          "relative_path": "@id"
+        },
+        {
+          "fieldname": "query:@type",
+          "relative_path": "@type"
+        },
+        {
+          "fieldname": "query:name",
+          "relative_path": "http://schema.org/name"
+        },
+        {
+          "fieldname": "query:description",
+          "relative_path": "http://schema.org/description"
+        }
+      ]
+    },
+    {
+      "fieldname": "query:license_info",
+      "relative_path": "https://schema.hbp.eu/minds/license_info",
+      "fields": [
+        {
+          "fieldname": "query:@id",
+          "relative_path": "@id"
+        },
+        {
+          "fieldname": "query:name",
+          "relative_path": "http://schema.org/name"
+        },
+        {
+          "fieldname": "query:url",
+          "relative_path": "http://schema.org/url"
+        },
+        {
+          "fieldname": "query:@type",
+          "relative_path": "@type"
+        }
+      ]
+    },
+    {
+      "fieldname": "query:owners",
+      "relative_path": "https://schema.hbp.eu/minds/owners",
+      "fields": [
+        {
+          "fieldname": "query:@type",
+          "relative_path": "@type"
+        },
+        {
+          "fieldname": "query:@id",
+          "relative_path": "@id"
+        },
+        {
+          "fieldname": "query:name",
+          "relative_path": "http://schema.org/name"
+        }
+      ]
+    },
+    {
+      "fieldname": "query:contributors",
+      "relative_path": "https://schema.hbp.eu/minds/contributors",
+      "fields": [
+        {
+          "fieldname": "query:@id",
+          "relative_path": "@id"
+        },
+        {
+          "fieldname": "query:name",
+          "relative_path": "http://schema.org/name"
+        },
+        {
+          "fieldname": "query:@type",
+          "relative_path": "@type"
+        }
+      ]
+    },
+    {
+      "fieldname": "query:doireference",
+      "relative_path": {
+        "@id": "https://schema.hbp.eu/minds/doireference",
+        "reverse": true
+      },
+      "fields": [
+        {
+          "fieldname": "query:doi",
+          "relative_path": "https://schema.hbp.eu/minds/doi"
+        },
+        {
+          "fieldname": "query:@type",
+          "relative_path": "@type"
+        },
+        {
+          "fieldname": "query:@id",
+          "relative_path": "@id"
+        }
+      ]
+    },
+    {
+      "fieldname": "query:modality",
+      "relative_path": "https://schema.hbp.eu/minds/modality",
+      "fields": [
+        {
+          "fieldname": "query:name",
+          "relative_path": "http://schema.org/name"
+        },
+        {
+          "fieldname": "query:@id",
+          "relative_path": "@id"
+        },
+        {
+          "fieldname": "query:@type",
+          "relative_path": "@type"
+        }
+      ]
+    },
+    {
+      "fieldname": "query:publications",
+      "relative_path": "https://schema.hbp.eu/minds/publications",
+      "fields": [
+        {
+          "fieldname": "query:doi",
+          "relative_path": "https://schema.hbp.eu/minds/doi"
+        },
+        {
+          "fieldname": "query:@id",
+          "relative_path": "@id"
+        },
+        {
+          "fieldname": "query:@type",
+          "relative_path": "@type"
+        },
+        {
+          "fieldname": "query:cite",
+          "relative_path": "https://schema.hbp.eu/minds/cite"
+        }
+      ]
+    },
+    {
+      "fieldname": "query:specimen_group",
+      "relative_path": "https://schema.hbp.eu/minds/specimen_group",
+      "fields": [
+        {
+          "fieldname": "query:@id",
+          "relative_path": "@id"
+        },
+        {
+          "fieldname": "query:@type",
+          "relative_path": "@type"
+        },
+        {
+          "fieldname": "query:name",
+          "relative_path": "http://schema.org/name"
+        }
+      ]
+    },
+    {
+      "fieldname": "query:v1.0.0",
+      "relative_path": {
+        "@id": "minds/core/fileassociation/v1.0.0",
+        "reverse": true
+      },
+      "fields": [
+        {
+          "fieldname": "query:absolute_path",
+          "relative_path": "https://schema.hbp.eu/cscs/absolute_path"
+        },
+        {
+          "fieldname": "query:byte_size",
+          "relative_path": "https://schema.hbp.eu/cscs/byte_size"
+        },
+        {
+          "fieldname": "query:content_type",
+          "relative_path": "https://schema.hbp.eu/cscs/content_type"
+        },
+        {
+          "fieldname": "query:hash",
+          "relative_path": "https://schema.hbp.eu/cscs/hash"
+        },
+        {
+          "fieldname": "query:hashcode",
+          "relative_path": "https://schema.hbp.eu/internal/hashcode"
+        },
+        {
+          "fieldname": "query:@id",
+          "relative_path": "@id"
+        },
+        {
+          "fieldname": "query:identifier",
+          "relative_path": "http://schema.org/identifier"
+        },
+        {
+          "fieldname": "query:lastModificationUserId",
+          "relative_path": "https://schema.hbp.eu/provenance/lastModificationUserId"
+        },
+        {
+          "fieldname": "query:last_modified",
+          "relative_path": "https://schema.hbp.eu/cscs/last_modified"
+        },
+        {
+          "fieldname": "query:modifiedAt",
+          "relative_path": "https://schema.hbp.eu/provenance/modifiedAt"
+        },
+        {
+          "fieldname": "query:name",
+          "relative_path": "http://schema.org/name"
+        },
+        {
+          "fieldname": "query:@type",
+          "relative_path": "@type"
+        }
+      ]
+    },
+    {
+      "fieldname": "query:name",
+      "relative_path": "http://schema.org/name"
+    },
+    {
+      "fieldname": "query:container_url",
+      "relative_path": "http://schema.org/container_url"
+    },
+    {
+      "fieldname": "query:createdAt",
+      "relative_path": "https://schema.hbp.eu/provenance/createdAt"
+    },
+    {
+      "fieldname": "query:createdBy",
+      "relative_path": "https://schema.hbp.eu/provenance/createdBy"
+    },
+    {
+      "fieldname": "query:dataDescriptorURL",
+      "relative_path": "https://schema.hbp.eu/minds/dataDescriptorURL"
+    },
+    {
+      "fieldname": "query:datalink",
+      "relative_path": "http://schema.org/datalink"
+    },
+    {
+      "fieldname": "query:datasetDOI",
+      "relative_path": "https://schema.hbp.eu/minds/datasetDOI"
+    },
+    {
+      "fieldname": "query:description",
+      "relative_path": "http://schema.org/description"
+    },
+    {
+      "fieldname": "query:external_datalink",
+      "relative_path": "https://schema.hbp.eu/minds/external_datalink"
+    },
+    {
+      "fieldname": "query:hashcode",
+      "relative_path": "http://hbp.eu/internal#hashcode"
+    },
+    {
+      "fieldname": "query:@id",
+      "relative_path": "@id",
+      "filter": {
+        "op": "ends_with",
+        "parameter": "datasetId"
+      }
+    },
+    {
+      "fieldname": "query:identifier",
+      "relative_path": "http://schema.org/identifier"
+    },
+    {
+      "fieldname": "query:immediateIndex",
+      "relative_path": "https://schema.hbp.eu/provenance/immediateIndex"
+    },
+    {
+      "fieldname": "query:lastModificationUserId",
+      "relative_path": "https://schema.hbp.eu/provenance/lastModificationUserId"
+    },
+    {
+      "fieldname": "query:modifiedAt",
+      "relative_path": "https://schema.hbp.eu/provenance/modifiedAt"
+    },
+    {
+      "fieldname": "query:reference",
+      "relative_path": "https://schema.hbp.eu/neuroglancer/reference"
+    },
+    {
+      "fieldname": "query:release_date",
+      "relative_path": "https://schema.hbp.eu/minds/release_date"
+    },
+    {
+      "fieldname": "query:@type",
+      "relative_path": "@type"
+    }
+  ]
+}

--- a/tools/store_test_kg_query.py
+++ b/tools/store_test_kg_query.py
@@ -1,0 +1,73 @@
+import requests
+from sys import argv
+import json
+from os import environ
+from uuid import UUID
+
+# get this from https://nexus-iam.humanbrainproject.org/v0/oauth2/authorize
+if 'EBRAINS_TOKEN' not in environ:
+    raise RuntimeError(
+        'Provide access token via EBRAINS_TOKEN environment variable')
+
+authheaders = {
+    'Content-Type': 'application/json',
+    'Authorization': 'Bearer {}'.format(environ['EBRAINS_TOKEN'])
+}
+
+# use query endpoint for datasets
+query_base = "https://kg.humanbrainproject.eu/query/minds/core/dataset/v1.0.0"
+
+
+def store_query(name, spec):
+    url = "{}/{}".format(query_base, name)
+    r = requests.put(
+        url,
+        data=spec,
+        headers=authheaders,
+    )
+    if r.ok:
+        print('Successfully stored the query at %s ' % r.url)
+    else:
+        print('Problem with "put" protocol on url: %s ' % r.url )
+        print(r)
+
+
+def query_dataset(name, dataset_id):
+    url = "{}/{}/instances?databaseScope=RELEASED&datasetId={}".format(
+        query_base,
+        name,
+        dataset_id,
+    )
+    r = requests.get(
+        url,
+        headers=authheaders,
+    )
+    if not r.ok:
+        print('Problem with "get" protocol on url: %s ' % r.url )
+        print(r.status_code)
+        print(r.text)
+        return
+
+    results = json.loads(r.content)
+    return results
+
+
+if __name__ == "__main__":
+    if len(argv) != 3:
+        print(
+            "USAGE: {} <query_name> <query_spec.json>|<dataset_id>".format(
+                argv[0]))
+        exit(1)
+
+    query_name = argv[1]
+    try:
+        dataset_id = UUID(argv[2])
+    except ValueError:
+        dataset_id = None
+
+    if dataset_id is None:
+        store_query(query_name, open(argv[2], 'r'))
+    else:
+        results = query_dataset(query_name, dataset_id)
+        if results:
+            print(json.dumps(results))


### PR DESCRIPTION
With appropriate credentials (see `ebrain-kg2ds` command docs), do:

```
$ datalad create demods
$ datalad ebrains-kg2ds -d demods aff5df97-f341-4370-97af-58d9f40c9877
```

This will yield a populated dataset, with files having EBRAINS metadata
assigned as git-annex metadata (demo selection).

The current query structure/results are dumped to demo what other
metadata are readily available, e.g. to auto-generate a README, etc.

@dickscheid Time to meet? ;-)