### PR TITLE
Fix wrong appveyor badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DataLad EBRAINS extension
 
-[![Build status](https://ci.appveyor.com/api/projects/status/f65qpwkv2rueii1d/branch/master?svg=true)](https://ci.appveyor.com/project/mih/datalad-ebrains/branch/master) [![codecov.io](https://codecov.io/github/datalad/datalad-ebrains/coverage.svg?branch=master)](https://codecov.io/github/datalad/datalad-ebrains?branch=master) [![crippled-filesystems](https://github.com/datalad/datalad-ebrains/workflows/crippled-filesystems/badge.svg)](https://github.com/datalad/datalad-ebrains/actions?query=workflow%3Acrippled-filesystems) [![docs](https://github.com/datalad/datalad-ebrains/workflows/docs/badge.svg)](https://github.com/datalad/datalad-ebrains/actions?query=workflow%3Adocs)
+[![Build status](https://ci.appveyor.com/api/projects/status/vld82efr44i6b6s3/branch/master?svg=true)](https://ci.appveyor.com/project/mih/datalad-ebrains/branch/master) [![codecov.io](https://codecov.io/github/datalad/datalad-ebrains/coverage.svg?branch=master)](https://codecov.io/github/datalad/datalad-ebrains?branch=master) [![crippled-filesystems](https://github.com/datalad/datalad-ebrains/workflows/crippled-filesystems/badge.svg)](https://github.com/datalad/datalad-ebrains/actions?query=workflow%3Acrippled-filesystems) [![docs](https://github.com/datalad/datalad-ebrains/workflows/docs/badge.svg)](https://github.com/datalad/datalad-ebrains/actions?query=workflow%3Adocs)
 
 EBRAINS is a digital research infrastructure, created by the EU-funded Human
 Brain Project, that gathers an extensive range of data and tools for brain


### PR DESCRIPTION
Although commit 4b09967b86b52415348edd58bf7d3c696c6e977c updated the url to which the badge redirects, the url of the image file still pointed to appveyor for datalad-mihextras. This is now mitigated.

Please double check in appveyor settings if I got the right one.