### PR TITLE
New `ebrains-authenticate` command

### DIFF
--- a/datalad_ebrains/__init__.py
+++ b/datalad_ebrains/__init__.py
@@ -20,6 +20,8 @@ command_suite = (
             # optional name of the command in the Python API
             'ebrains_kg2ds'
         ),
+        ('datalad_ebrains.authenticate', 'Authenticate',
+         'ebrains-authenticate', 'ebrains_authenticate')
     ]
 )
 

--- a/datalad_ebrains/authenticate.py
+++ b/datalad_ebrains/authenticate.py
@@ -1,0 +1,69 @@
+import sys
+
+from datalad.interface.base import (
+    Interface,
+    build_doc,
+)
+from datalad.interface.results import get_status_dict
+from datalad.interface.utils import (
+    generic_result_renderer,
+    eval_results,
+)
+from datalad.support.exceptions import CapturedException
+from datalad.ui import ui
+
+
+@build_doc
+class Authenticate(Interface):
+    @staticmethod
+    @eval_results
+    def __call__():
+        from kg_core.kg import kg
+        k = kg()
+
+        # this will present instructions, which URL to visit, and will return
+        # with a token str, once a user has successfully auhtenticated at
+        # EBRAINS
+        try:
+            k.with_device_flow()
+            # we redirect stdout to stderr temporarily to be able to only
+            # output the token on stdout, separate from the instructions that
+            # kg-core unconditionally prints to stdout.  this facilitates
+            # external reuse of the token (e.g. define as an ENV var)
+            with _RedirectStdErr2StdOut():
+                token = k._token_handler.get_token()
+        except Exception as e:
+            yield get_status_dict(
+                action='ebrains-authenticate',
+                status='error',
+                exception=CapturedException(e),
+            )
+            return
+        yield get_status_dict(
+            action='ebrains-authenticate',
+            status='ok',
+            token=token,
+        )
+
+    @staticmethod
+    def custom_result_renderer(res, **kwargs):
+        if res['status'] != 'ok' or res['action'] != 'ebrains-authenticate' \
+                or 'token' not in res:
+            # not what we were aiming -> report
+            generic_result_renderer(res)
+            return
+        # naked print of the token, rather then some precrafted KG_TOKEN=...
+        # line. This should offer maximum flexibility for reuse on different
+        # platforms/shells
+        ui.message(res["token"])
+
+
+class _RedirectStdErr2StdOut:
+    """Utility context manager to redirect stdout to stderr"""
+    def __enter__(self):
+        self._stdout = sys.stdout
+        sys.stdout = sys.stderr
+        return self
+
+    def __exit__(self, *args):
+        sys.stdout = self._stdout

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,6 +11,7 @@ High-level API commands
 .. autosummary::
    :toctree: generated
 
+   ebrains_authenticate
    ebrains_kg2ds
 
 
@@ -20,6 +21,7 @@ Command line reference
 .. toctree::
    :maxdepth: 1
 
+   generated/man/datalad-ebrains-authenticate
    generated/man/datalad-ebrains-kg2ds
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,8 @@
 [metadata]
-url = https://github.com/datalad/datalad-extension-template
+url = https://github.com/datalad/datalad-ebrains
 author = The DataLad Team and Contributors
 author_email = team@datalad.org
-description = demo DataLad extension package
+description = HBP/EBRAINS support
 long_description = file:README.md
 long_description_content_type = text/markdown; charset=UTF-8
 license = MIT
@@ -16,6 +16,7 @@ python_requires = >= 3.7
 install_requires =
     datalad >= 0.17
     datalad_next
+    ebrains-kg-core
 packages = find_namespace:
 include_package_data = True
 
@@ -26,6 +27,7 @@ include = datalad_ebrains*
 # this matches the name used by -core and what is expected by some CI setups
 devel =
     pytest
+    pytest-cov
     coverage
 
 [options.entry_points]


### PR DESCRIPTION
This hopefully resolves the long-standing authentication issue for good.

It is built on the `ebrains-kg-core` library that (among other things) implements the "device flow" authentication that seems most suitable for the purpose and target audience of this package.

In the standard case `datalad ebrains-authenticate` is called without any arguments. It presents instructions to the terminal with a URL to visit for authentication using a browser. Once successful, it returns a result record with a token.

A default result renderer is in place to enable shell-based usage ala

```
export KG_TOKEN=`datalad ebrains-authenticate`
```

that puts the token into the `KG_TOKEN` environment variable. This variable is recognized by the `ebrains-kg-core` itself too, and enabled token re-use with the following pattern:

```py
>>> from kg_core.kg import kg
>>> k=kg()
>>> k.with_token()
>>> kg_client= k.build()
>>> kg_client.instances.list("https://openminds.ebrains.eu/core/Person")
```

Closes #30