### PR TITLE
Clone from EBRAINS

### DIFF
--- a/datalad_ebrains/__init__.py
+++ b/datalad_ebrains/__init__.py
@@ -9,22 +9,12 @@ command_suite = (
     # description of the command suite, displayed in cmdline help
     "HBP/EBRAINS support",
     [
-        # specification of a command, any number of commands can be defined
-        (
-            # importable module that contains the command implementation
-            'datalad_ebrains.kg2ds',
-            # name of the command class implementation in above module
-            'KnowledgeGraph2Dataset',
-            # optional name of the command in the cmdline API
-            'ebrains-kg2ds',
-            # optional name of the command in the Python API
-            'ebrains_kg2ds'
-        ),
         ('datalad_ebrains.authenticate', 'Authenticate',
          'ebrains-authenticate', 'ebrains_authenticate')
     ]
 )
 
+import datalad_ebrains.patches
 
 from . import _version
 __version__ = _version.get_versions()['version']

--- a/datalad_ebrains/kg2ds.py
+++ b/datalad_ebrains/kg2ds.py
@@ -196,11 +196,12 @@ def process_revision(ds, rev_id, rev_record, auth_token):
         # we have a better idea than "auto"
         exclude_autometa='*',
         # and here it is
-        meta=(
-            'content_type={content_type}',
+        #meta=(
+        # some EBRAINS dataset don't even have that
+        #    'content_type={content_type}',
         #    'ebrains_last_modified={last_modified}',
         #    'ebrain_last_modification_userid={last_modifier}',
-        ),
+        #),
         fast=True,
         save=False,
         result_renderer='disabled',

--- a/datalad_ebrains/kg_query.py
+++ b/datalad_ebrains/kg_query.py
@@ -93,7 +93,7 @@ def query_kg4dataset(auth_token, dataset_id):
     return qres
 
 
-def get_token(credential, allow_interactive=True):
+def get_token():
     if 'DATALAD_ebrains_token' in os.environ:
         return os.environ['DATALAD_ebrains_token']
     elif 'KG_TOKEN' in os.environ:
@@ -208,9 +208,9 @@ def _filerec2annexrec(rec, baseurl):
     if size is not None:
         props['size'] = size
 
-    content_type = rec.get('format', {}).get('fullName')
+    content_type = rec.get('format', {})
     if content_type:
-        props['content_type'] = content_type
+        props['content_type'] = content_type.get('fullName')
 
     # TODO can we get a modification time?
     # can we get the entity that last modified this file record

--- a/datalad_ebrains/patches/__init__.py
+++ b/datalad_ebrains/patches/__init__.py
@@ -1,0 +1,1 @@
+from . import clone

--- a/datalad_ebrains/patches/clone.py
+++ b/datalad_ebrains/patches/clone.py
@@ -1,0 +1,101 @@
+import logging
+from typing import (
+    Dict,
+    List,
+    Tuple,
+)
+
+from datalad_next.patches import clone_utils as origmod
+
+from datalad.runner.exception import CommandError
+from datalad.distribution.dataset import Dataset
+
+lgr = logging.getLogger('datalad.core.distributed.clone')
+
+
+def _try_clone_candidate(
+        *,
+        destds: Dataset,
+        cand: Dict,
+        clone_opts: List) -> Tuple:
+    """Attempt a clone from a single candidate
+
+    destds: Dataset
+      The target dataset the clone should materialize at.
+    candidate_sources: list
+      Each value is a dict with properties, as returned by
+      `_generate_candidate_clone_sources()`
+    clone_opts: list
+      Options to be passed on to `_try_clone_candidate()`
+
+    Returns
+    -------
+    (str, str or None, dict or None)
+      The first item is the effective URL a clone was attempted from.
+      The second item is `None` if the clone was successful, or an
+      error message (specifically a CommandError), detailing the failure
+      for the specific URL.
+      If the third item is not `None`, it must be a result dict that
+      should be yielded, and no further clone attempt (even when
+      other candidates remain) will be attempted.
+    """
+    if not cand.get('source', '').startswith(
+            'https://search.kg.ebrains.eu/instances/'):
+        return orig_try_clone_candidate(
+            destds=destds,
+            cand=cand,
+            clone_opts=clone_opts,
+        )
+
+    # this is a potential dataset instance landing page
+    from datalad_ebrains.kg_query import (
+        get_token,
+        query_kg4dataset,
+        KGQueryException,
+    )
+    from datalad_ebrains.kg2ds import process_revision
+
+    source_url = cand['source']
+    # pull the dataset ID from the URL
+    # we are not checking whether this is formatted like a UUID, because we
+    # know about some cases, whether it is not and is nevertheless correct
+    # from the KG point of view
+    kgdsid = source_url.split('/')[4]
+
+    if not kgdsid:
+        raise ValueError('No EBRAINS dataset ID given in clone URL')
+
+    auth_token = get_token()
+
+    try:
+        query_res = query_kg4dataset(auth_token, kgdsid)
+    except KGQueryException as e:
+        return (
+            source_url,
+            # shoehorn into CommandError due to
+            # https://github.com/datalad/datalad/issues/7148
+            CommandError(stderr=e),
+            None,
+        )
+
+    # if we got here, the basic query went well. time to create a dataset
+    destds.create(result_renderer='disabled')
+
+    # we need to unwind the generator here, clone() in its present shape does
+    # not support yielding interim results
+    # TODO best to wrap this into a progress bar
+    try:
+        list(process_revision(destds, kgdsid, query_res, auth_token))
+    except Exception as e:
+        # Cannot be msg= due to https://github.com/datalad/datalad/issues/7148
+        return source_url, CommandError(stderr=str(e)), None
+
+    # success
+    return source_url, None, None
+
+
+# apply patch
+lgr.debug(
+    'Apply datalad-ebrains patch to clone_utils.py:_try_clone_candidate()')
+orig_try_clone_candidate = origmod._try_clone_candidate
+origmod._try_clone_candidate = _try_clone_candidate

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ classifiers =
 python_requires = >= 3.7
 install_requires =
     datalad >= 0.17
-    datalad_next
+    datalad_next >= 0.6.1
     ebrains-kg-core
 packages = find_namespace:
 include_package_data = True


### PR DESCRIPTION
This is a sketch of a clone patch to support direct "clone" from the EBRAINS knowledge graph.

However, to clone machinery is to strict to allow for non-git-clone-approaches to bootstrap a local git repository.

For example:

- it is presently impossible to have a "cloned" repository that hase no remote configured afterwards
- it is presently impossible to have a dataset that is already fully bootstrapped at the clone stage, such that no `git annex init` and associated post-processing would run.

Ping datalad/datalad-ebrains#21