### PR TITLE
Ensure file paths from CSCS object store URLs are not absolute

### DIFF
--- a/datalad_ebrains/fairgraph_query.py
+++ b/datalad_ebrains/fairgraph_query.py
@@ -296,7 +296,8 @@ def _get_fname_cscs_repo(baseurl, prefix, f):
     # strip file repository prefix
     # TODO check https://github.com/datalad/datalad-ebrains/issues/39
     # if that is desirable
-    fname = fname[len(prefix):]
+    # also strip any leading slash, any absolute path is invalid here
+    fname = fname[len(prefix):].lstrip('/')
     # we have a relative posix path now
     fname = PurePosixPath(fname)
     # turn into a Platform native path


### PR DESCRIPTION
This fixes a bug that I introduced when generalizing the code to also work with the EBRAINS data proxy.

Closes #56