### PR TITLE
Sketch to support (private) data-proxy dataset

### DIFF
--- a/datalad_ebrains/fairgraph_query.py
+++ b/datalad_ebrains/fairgraph_query.py
@@ -186,9 +186,14 @@ class FairGraphQuery:
         # EBRAINS uses different file repositories that need slightly
         # different handling
         dvr_url_p = urlparse(dvr.iri.value)
+        # public data-proxy datasets
         if dvr_url_p.netloc == 'data-proxy.ebrains.eu' \
                 and dvr_url_p.path.startswith('/api/v1/public/buckets/'):
-            get_fname = _get_fname_dataproxy_v1_bucket
+            get_fname = _get_fname_dataproxy_v1_bucket_public
+        # private data-proxy datasets (e.g. human data gateway)
+        elif dvr_url_p.netloc == 'data-proxy.ebrains.eu' \
+                and dvr_url_p.path.startswith('/api/v1/buckets/'):
+            get_fname = _get_fname_dataproxy_v1_bucket_private
         elif dvr_url_p.netloc == 'object.cscs.ch' \
                 and dvr_url_p.query.startswith('prefix='):
             # get the repos base url by removing the query string
@@ -281,13 +286,22 @@ class FairGraphQuery:
         }
 
 
-def _get_fname_dataproxy_v1_bucket(f):
+def _get_fname_dataproxy_v1_bucket_public(f):
     f_url_p = urlparse(f.iri.value)
     assert f_url_p.netloc == 'data-proxy.ebrains.eu'
     assert f_url_p.path.startswith('/api/v1/public/buckets/')
     path = PurePosixPath(f_url_p.path)
     # take everything past the bucket_id and turn into a Platform native path
     return Path(*path.parts[6:])
+
+
+def _get_fname_dataproxy_v1_bucket_private(f):
+    f_url_p = urlparse(f.iri.value)
+    assert f_url_p.netloc == 'data-proxy.ebrains.eu'
+    assert f_url_p.path.startswith('/api/v1/buckets/')
+    path = PurePosixPath(f_url_p.path)
+    # take everything past the bucket_id and turn into a Platform native path
+    return Path(*path.parts[5:])
 
 
 def _get_fname_cscs_repo(baseurl, prefix, f):

--- a/datalad_ebrains/fairgraph_query.py
+++ b/datalad_ebrains/fairgraph_query.py
@@ -192,6 +192,7 @@ class FairGraphQuery:
                 and dvr_url_p.path.startswith('/api/v1/public/buckets/'):
             iter_files = partial(
                 self.iter_files_dp,
+                dsid=kg_dsver.uuid,
                 auth=False,
                 get_fname=_get_fname_dataproxy_v1_bucket_public,
             )
@@ -200,6 +201,7 @@ class FairGraphQuery:
                 and dvr_url_p.path.startswith('/api/v1/buckets/'):
             iter_files = partial(
                 self.iter_files_dp,
+                dsid=kg_dsver.uuid,
                 auth=True,
                 get_fname=_get_fname_dataproxy_v1_bucket_private,
             )
@@ -234,12 +236,12 @@ class FairGraphQuery:
         # (url: str, name: str, md5sum: str, size: int)
         yield from iter_files(dvr)
 
-    def iter_files_dp(self, dvr, auth, get_fname, chunk_size=10000):
+    def iter_files_dp(self, dvr, dsid, auth, get_fname, chunk_size=10000):
         """Yield file records from a data proxy query"""
-        bucket_url = f'https://data-proxy.ebrains.eu/api/v1/{dvr.name}'
+        dsurl = f'https://data-proxy.ebrains.eu/api/v1/datasets/{dsid}'
         response = requests.get(
             # TODO handle properly
-            f'{bucket_url}?limit=10000',
+            f'{dsurl}?limit=10000',
             # data proxy API will 400 if auth is sent for public resources
             headers={
                 "Content-Type": "application/json",
@@ -258,7 +260,7 @@ class FairGraphQuery:
             # we need
             # (url: str, name: str, md5sum: str, size: int)
             yield dict(
-                url=f'{bucket_url}/{f["name"]}',
+                url=f'{dsurl}/{f["name"]}',
                 name=f['name'],
                 md5sum=f['hash'],
                 size=f['bytes'],

--- a/datalad_ebrains/tests/conftest.py
+++ b/datalad_ebrains/tests/conftest.py
@@ -1,9 +1,15 @@
+import os
 import pytest
 from unittest.mock import patch
 
 
 @pytest.fixture(scope="session", autouse=True)
 def authenticate():
+    if 'KG_AUTH_TOKEN' in os.environ:
+        # we seem to have what we need
+        yield
+        return
+
     from datalad.api import ebrains_authenticate
     token = ebrains_authenticate(
         result_renderer='disabled',

--- a/datalad_ebrains/tests/test_clone.py
+++ b/datalad_ebrains/tests/test_clone.py
@@ -89,7 +89,7 @@ def test_clone_invalid_call(tmp_path):
     # make sure the parameter validation is working
     from datalad.api import ebrains_clone
     # always needs a `source`
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         ebrains_clone()
     # must contain a UUID
     with pytest.raises(ValueError):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -115,9 +115,6 @@ pygments_style = 'sphinx'
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
 
-# Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
-
 # -- Options for HTML output ----------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ classifiers =
 python_requires = >= 3.7
 install_requires =
     datalad >= 0.17
-    datalad_next >= 1.0.0b2
+    datalad_next >= 1.0.0b3
     ebrains-kg-core
     fairgraph >= 0.11
 packages = find_namespace:

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ install_requires =
     datalad >= 0.17
     datalad_next >= 1.0.0b2
     ebrains-kg-core
-    fairgraph
+    fairgraph >= 0.11
 packages = find_namespace:
 include_package_data = True
 


### PR DESCRIPTION
This change started out by merely adding the ability to recognize and process non-public dataset data-proxy URLs.

However, it was not enough to support such datasets, because the underlying `fairgraph` query to get a dataset's file listing returns no results.

The query is essentially this

```py
batch = omcore.File.list(
    self.client,
    file_repository=dvr,
    size=chunk_size,
    from_index=cur_index)
```

and for the dataset referenced in
https://github.com/datalad/datalad-ebrains/issues/58 it returns an empty list with

- a properly authenticated `client`
- `dvr`: `FileRepository(name='buckets/d-07ab1665-73b0-40c5-800e-557bc319109d', iri=IRI(https://data-proxy.ebrains.eu/api/v1/buckets/d-07ab1665-73b0-40c5-800e-557bc319109d)...`
- `chunk_size`: 10000
- `cur_index`: 0

With the same requesting account, I can browser-visit https://data-proxy.ebrains.eu/datasets/07ab1665-73b0-40c5-800e-557bc319109d and see a file listing.


To mitigate this issue, the PR now queries the data proxy API directly -- leading to noticeable speed-ups.

This PR prepares for addressing #58, but does not achieve it, due to outstanding authentication issues.